### PR TITLE
Specify a specific adapter to use for the connection.

### DIFF
--- a/lib/include/modbus/IModbusManager.h
+++ b/lib/include/modbus/IModbusManager.h
@@ -96,6 +96,7 @@ public:
      * @brief Create a TCP channel.
      * @param name      Name associated with the channel. This name will appear in the logs.
      * @param endpoint  IPv4 endpoint to which the channel will be connected.
+     * @param adapter   Network adapter to use for establishing the connection.
      * @param level     Logging level of the channel.
      * @returns Shared pointer of a @ref IChannel instance.
      *
@@ -105,6 +106,7 @@ public:
      */
     virtual std::shared_ptr<IChannel> create_tcp_channel(const std::string& name,
                                                          const Ipv4Endpoint& endpoint,
+                                                         const std::string& adapter = "",
                                                          const LoggingLevel level = LoggingLevel::Info) = 0;
 
     /**

--- a/lib/src/ModbusManagerImpl.cpp
+++ b/lib/src/ModbusManagerImpl.cpp
@@ -39,6 +39,7 @@ ModbusManagerImpl::~ModbusManagerImpl()
 
 std::shared_ptr<IChannel> ModbusManagerImpl::create_tcp_channel(const std::string& name,
                                                                 const Ipv4Endpoint& endpoint,
+                                                                const std::string& adapter,
                                                                 const LoggingLevel level)
 {
     auto executor = std::make_shared<exe4cpp::StrandExecutor>(m_io_service);
@@ -46,7 +47,8 @@ std::shared_ptr<IChannel> ModbusManagerImpl::create_tcp_channel(const std::strin
     auto connection_logger = m_logger->clone(name + " - Connection", level);
     auto tcp_connection = std::make_shared<AsioTcpConnection>(connection_logger,
                                                               executor,
-                                                              endpoint);
+                                                              endpoint,
+                                                              adapter);
 
     auto channel = std::make_shared<ChannelTcp>(executor, m_logger->clone(name, level), tcp_connection);
 

--- a/lib/src/ModbusManagerImpl.h
+++ b/lib/src/ModbusManagerImpl.h
@@ -31,6 +31,7 @@ public:
 
     std::shared_ptr<IChannel> create_tcp_channel(const std::string& name,
                                                  const Ipv4Endpoint& endpoint,
+                                                 const std::string& adapter,
                                                  const LoggingLevel level) override;
     void shutdown() override;
 

--- a/lib/src/channel/AsioTcpConnection.cpp
+++ b/lib/src/channel/AsioTcpConnection.cpp
@@ -25,10 +25,12 @@ namespace modbus
 
 AsioTcpConnection::AsioTcpConnection(std::shared_ptr<Logger> logger,
                                      std::shared_ptr<exe4cpp::StrandExecutor> executor,
-                                     const Ipv4Endpoint& endpoint)
+                                     const Ipv4Endpoint& endpoint,
+                                     const std::string& adapter)
         : m_logger{logger},
           m_ip_endpoint{endpoint},
           m_executor{executor},
+          m_adapter{adapter},
           m_resolver{*executor->get_context()},
           m_tcp_socket{*executor->get_context()},
           m_current_connection_status{ConnectionStatus::NotConnected}
@@ -49,12 +51,27 @@ void AsioTcpConnection::send(const ser4cpp::rseq_t& data)
     {
         m_logger->info("Establishing connection to {}:{}", m_ip_endpoint.get_hostname(), m_ip_endpoint.get_port());
 
+        // Connect to the proper adapter
+        asio::error_code ec{};
+        const auto address = asio::ip::address::from_string(m_adapter.empty() ? "0.0.0.0" : m_adapter, ec);
+        if(ec) { m_logger->error("from_address error: {}", ec.message()); return; }
+
+        asio::ip::tcp::endpoint endpoint{};
+        endpoint.address(address);
+        endpoint.port(0);
+        m_tcp_socket.open(asio::ip::tcp::v4(), ec);
+        if(ec) { m_logger->error("socket open error: {}", ec.message()); return; }
+
+        m_tcp_socket.bind(endpoint, ec);
+        if(ec) { m_logger->error("socket bind error: {}", ec.message()); return; }
+
+        // Start connecting
         m_current_connection_status = ConnectionStatus::Connecting;
         asio::ip::tcp::resolver::query query{m_ip_endpoint.get_hostname(), std::to_string(m_ip_endpoint.get_port())};
         m_resolver.async_resolve(query,
                                  m_executor->wrap(std::bind(&AsioTcpConnection::resolve_handler,
-                                                         std::dynamic_pointer_cast<AsioTcpConnection>(shared_from_this()),
-                                                         _1, _2)));
+                                                            std::dynamic_pointer_cast<AsioTcpConnection>(shared_from_this()),
+                                                            _1, _2)));
     }
 
     if(m_current_connection_status == ConnectionStatus::Connected)

--- a/lib/src/channel/AsioTcpConnection.h
+++ b/lib/src/channel/AsioTcpConnection.h
@@ -17,6 +17,7 @@
 #define MODBUS_ASIOTCPCONNECTION_H
 
 #include <array>
+#include <string>
 #include "exe4cpp/asio/StrandExecutor.h"
 #include "ser4cpp/container/Buffer.h"
 
@@ -32,7 +33,8 @@ class AsioTcpConnection : public ITcpConnection
 public:
     AsioTcpConnection(std::shared_ptr<Logger> logger,
                       std::shared_ptr<exe4cpp::StrandExecutor> executor,
-                      const Ipv4Endpoint& endpoint);
+                      const Ipv4Endpoint& endpoint,
+                      const std::string& adapter = "");
 
     void set_listener(std::weak_ptr<IConnectionListener> listener) override;
     void send(const ser4cpp::rseq_t& data) override;
@@ -58,6 +60,7 @@ private:
     std::shared_ptr<Logger> m_logger;
     Ipv4Endpoint m_ip_endpoint;
     std::shared_ptr<exe4cpp::StrandExecutor> m_executor;
+    std::string m_adapter;
     asio::ip::tcp::resolver m_resolver;
     asio::ip::tcp::socket m_tcp_socket;
 


### PR DESCRIPTION
- When creating a session, it is now possible to specify a particular adapter to use.
- By default, `0.0.0.0` is used.